### PR TITLE
CIの修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - 'app/**.py'
       - 'app/*.py'
+      - 'tests/**.py'
+      - 'tests/*.py'
 
 permissions:
   checks: write
@@ -48,6 +50,8 @@ jobs:
           PATTERNS: |
             app/**/*.py
             app/*.py
+            tests/**/*.py
+            tests/*.py
           SEPARATOR: ' '
 
       - name: Trim single quotes


### PR DESCRIPTION
# なぜこの対応が必要か
- 可読性が悪い
- 不要な処理がある/ほかに必要な処理がある

# 対応したこと
- タイムアウト値を指定
- CIキック条件を指定
- Lintが落ちても最後まで処理を実行するように、適宜条件追加
-  mypyの出力のreporter: github-pr-checkに変更
  - github-pr-reviewだとなぜか出力できない時があるので使用しない
- testとLintのJobを分けた
- Mypyとtestが落ちた時はPRにコメントを付ける

# 対応していないこと
- 既存のファイルでmypyとBlackとRuffで怒られるファイルの修正