### PR TITLE
fix: ユーザーとかメアドが重複したときに409を返す

### DIFF
--- a/app/functions/user.py
+++ b/app/functions/user.py
@@ -10,6 +10,7 @@ from mangum import Mangum
 
 from app.errors.retro_app_error import (
     RetroAppAuthenticationError,
+    RetroAppColmunUniqueError,
     RetroAppRecordNotFoundError,
     RetroAppTokenExpiredError,
 )
@@ -73,7 +74,14 @@ def signup_user(
     user: UserModel = UserModel(
         name=user_params.name, email=user_params.email, password=user_params.password
     )
-    user_repo.save(user=user)
+    try:
+        user_repo.save(user=user)
+    except RetroAppColmunUniqueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=e.message,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
 
     return JSONResponse(
         status_code=status.HTTP_201_CREATED,

--- a/tests/functions/test_user_function.py
+++ b/tests/functions/test_user_function.py
@@ -90,10 +90,14 @@ class TestUserFunction:
                 "password": "testpassword",
             }
 
-            response = client.post("/api/v1/sign_up", json=user_data)
+            response_1st = client.post("/api/v1/sign_up", json=user_data)
+            assert response_1st.status_code == 201
+            assert response_1st.json() == {"message": "ユーザー登録が成功しました。"}
 
-            assert response.status_code == 201
-            assert response.json() == {"message": "ユーザー登録が成功しました。"}
+            response_2nd = client.post("/api/v1/sign_up", json=user_data)
+            assert response_2nd.status_code == 409
+            assert response_2nd.json() == {"detail": "指定されたメールアドレスはすでに登録されています。"}
+
             # TODO:異常系のテストを追加する
             # DBに保存されているかの観点が必要。
             # パスワードのバリデーションがすり抜けている気がする...


### PR DESCRIPTION
# 対応したこと
- [x] userFunctionでRetroAppColmunUniqueErrorの時に、409を返すようにした
- [x] そのテスト追加
