### PR TITLE
chore: Update docker compose command in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Setup postgres
         run: |
-          docker-compose up -d
+          docker compose up -d
 
       - name: Read python version from .python-version
         id: python_version


### PR DESCRIPTION
The reason is failed ci because `docker compose` command is changed 
コマンドが変わってCIが落ちていたため
https://docs.docker.com/compose/migrate/