### PR TITLE
Revert "chore: update lib for vulnerbility"

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -693,11 +693,11 @@
         },
         "starlette": {
             "hashes": [
-                "sha256:1a3139688fb298ce5e2d661d37046a66ad996ce94be4d4983be019a23a04ea35",
-                "sha256:c494a22fae73805376ea6bf88439783ecfba9aac88a43911b48c653437e784c4"
+                "sha256:04a92830a9b6eb1442c766199d62260c3d4dc9c4f9188360626b1e0273cb7077",
+                "sha256:632f420a9d13e3ee2a6f18f437b0a9f1faecb0bc42e1942aa2ea0e379a4c4206"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.40.0"
+            "version": "==0.38.5"
         },
         "typing-extensions": {
             "hashes": [
@@ -719,11 +719,11 @@
     "develop": {
         "anyio": {
             "hashes": [
-                "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c",
-                "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d"
+                "sha256:5aadc6a1bbb7cdb0bede386cac5e2940f5e2ff3aa20277e991cf028e0585ce94",
+                "sha256:c1b2d8f46a8a812513012e1107cb0e68c17159a7a594208005a57dc776e1bdc7"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==4.6.2.post1"
+            "markers": "python_version >= '3.8'",
+            "version": "==4.4.0"
         },
         "black": {
             "hashes": [
@@ -894,11 +894,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
-                "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
+                "sha256:69297d5da0cc9281c77efffb4e730254dd45943f45bbfb461de5991713989b1e",
+                "sha256:e5c5dafde284f26e9e0f28f6ea2d6400abd5ca099864a67f576f3981c6476124"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.10"
+            "version": "==3.9"
         },
         "iniconfig": {
             "hashes": [


### PR DESCRIPTION
Reverts talasago/retro_app#206


fastapiとstarletteのバージョン指定が合わないため
https://github.com/talasago/retro_app/actions/runs/11933325441/job/33260145424