### PR TITLE
eslint-plugin-react-max-propsのドッグフーディングによるPresenter props整理

### DIFF
--- a/client/src/features/Login/components/container/LoginModalContainer.tsx
+++ b/client/src/features/Login/components/container/LoginModalContainer.tsx
@@ -93,11 +93,7 @@ const LoginModalContainer: FC<LoginModalProps> = ({ isOpen, onCloseModal }) => {
       <LoginModalPresenter
         isOpen={isOpen}
         onClose={onCloseModal}
-        register={register}
-        handleSubmit={handleSubmit}
-        onSubmit={onSubmit}
-        errors={errors}
-        isSubmitting={isSubmitting}
+        form={{ register, handleSubmit, onSubmit, errors, isSubmitting }}
       />
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/features/Login/components/presenter/LoginModalPresenter.tsx
+++ b/client/src/features/Login/components/presenter/LoginModalPresenter.tsx
@@ -27,9 +27,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import LockIcon from '@mui/icons-material/Lock';
 import { type LoginFormSchema } from '../schemas/loginFormSchema';
 
-interface LoginModalPresenterProps {
-  isOpen: boolean;
-  onClose: () => void;
+interface LoginFormProps {
   register: UseFormRegister<LoginFormSchema>;
   handleSubmit: UseFormHandleSubmit<LoginFormSchema>;
   onSubmit: SubmitHandler<LoginFormSchema>;
@@ -37,14 +35,16 @@ interface LoginModalPresenterProps {
   isSubmitting: boolean;
 }
 
+interface LoginModalPresenterProps {
+  isOpen: boolean;
+  onClose: () => void;
+  form: LoginFormProps;
+}
+
 const LoginModalPresenter: FC<LoginModalPresenterProps> = ({
   isOpen,
   onClose,
-  register,
-  handleSubmit,
-  onSubmit,
-  errors,
-  isSubmitting,
+  form: { register, handleSubmit, onSubmit, errors, isSubmitting },
 }) => {
   return (
     <div>

--- a/client/src/features/RetrospectiveMethodList/components/container/RetrospectiveMethodListContainer.tsx
+++ b/client/src/features/RetrospectiveMethodList/components/container/RetrospectiveMethodListContainer.tsx
@@ -101,15 +101,21 @@ const RetrospectiveMethodListContainer: React.FC = () => {
   const memorizedPresenter = useMemo(
     () => (
       <RetrospectiveMethodListPresenter
-        retrospectiveMethods={retrospectiveMethods}
-        retrospectiveSceneNames={retrospectiveSceneName}
-        isShowScrollToTop={isShowScrollToTop}
-        isShowRetrospectiveMethodList={isShowRetrospectiveMethodList}
-        onClickScrollToButton={handleClickScrollToButton}
-        onClickRetrospectiveMethodPaper={handleClickRetrospectiveMethodPaper}
-        onClickRetroMethodListShowButton={handleClickRetroMethodListShowButton}
-        onClickRandomButton={handleClickRandomButton}
-        onChangeScenesCheckbox={handleChangeScenesCheckbox}
+        searchArea={{
+          retrospectiveSceneName,
+          onClickRetroMethodListShowButton: handleClickRetroMethodListShowButton,
+          onClickRandomButton: handleClickRandomButton,
+          onChangeScenesCheckbox: handleChangeScenesCheckbox,
+        }}
+        paperArea={{
+          retrospectiveMethods,
+          onClickRetrospectiveMethodPaper: handleClickRetrospectiveMethodPaper,
+          isShow: isShowRetrospectiveMethodList,
+        }}
+        scrollTop={{
+          isShow: isShowScrollToTop,
+          onClick: handleClickScrollToButton,
+        }}
       />
     ),
     [

--- a/client/src/features/RetrospectiveMethodList/components/presenter/RetrospectiveMethodListPresenter.tsx
+++ b/client/src/features/RetrospectiveMethodList/components/presenter/RetrospectiveMethodListPresenter.tsx
@@ -26,44 +26,25 @@ import RetrospectiveMethodPaper from './RetrospectiveMethodPaper';
 import RetrospectiveMethodSearchButton from './RetrospectiveMethodSearchButton';
 
 interface retrospectiveMethodListPresenterProps {
-  retrospectiveMethods: RetrospectiveMethod[];
-  retrospectiveSceneNames: RetrospectiveSceneNames;
-  isShowScrollToTop: boolean;
-  isShowRetrospectiveMethodList: boolean;
-  onClickScrollToButton: () => void;
-  onClickRetrospectiveMethodPaper: (method: RetrospectiveMethod) => void;
-  onClickRetroMethodListShowButton: () => void;
-  onClickRandomButton: () => void;
-  onChangeScenesCheckbox: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  searchArea: SearchAreaProps;
+  paperArea: RetrospectiveMethodPaperAreaProps & { isShow: boolean };
+  scrollTop: ScrollToTopProps;
 }
 const RetrospectiveMethodListPresenter: React.FC<
   retrospectiveMethodListPresenterProps
-> = ({
-  retrospectiveMethods,
-  retrospectiveSceneNames,
-  isShowScrollToTop,
-  isShowRetrospectiveMethodList,
-  onClickScrollToButton,
-  onClickRetrospectiveMethodPaper,
-  onClickRetroMethodListShowButton,
-  onClickRandomButton,
-  onChangeScenesCheckbox,
-}) => {
+> = ({ searchArea, paperArea, scrollTop }) => {
   return (
     <Box>
-      <SearchArea
-        retrospectiveSceneName={retrospectiveSceneNames}
-        onClickRetroMethodListShowButton={onClickRetroMethodListShowButton}
-        onClickRandomButton={onClickRandomButton}
-        onChangeScenesCheckbox={onChangeScenesCheckbox}
-      />
-      {isShowRetrospectiveMethodList && (
+      <SearchArea {...searchArea} />
+      {paperArea.isShow && (
         <RetrospectiveMethodPaperArea
-          retrospectiveMethods={retrospectiveMethods}
-          onClickRetrospectiveMethodPaper={onClickRetrospectiveMethodPaper}
+          retrospectiveMethods={paperArea.retrospectiveMethods}
+          onClickRetrospectiveMethodPaper={
+            paperArea.onClickRetrospectiveMethodPaper
+          }
         />
       )}
-      <ScrollToTop isShow={isShowScrollToTop} onClick={onClickScrollToButton} />
+      <ScrollToTop {...scrollTop} />
     </Box>
   );
 };

--- a/client/src/features/SignUp/components/container/SignUpModalContainer.tsx
+++ b/client/src/features/SignUp/components/container/SignUpModalContainer.tsx
@@ -95,11 +95,7 @@ const SignUpModalContainer: FC = () => {
       <SignUpModalPresenter
         isOpen={isOpen}
         onClose={handleCloseSignUpModal}
-        register={register}
-        handleSubmit={handleSubmit}
-        onSubmit={onSubmit}
-        errors={errors}
-        isSubmitting={isSubmitting}
+        form={{ register, handleSubmit, onSubmit, errors, isSubmitting }}
       />
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/src/features/SignUp/components/presenter/SignUpModalPresenter.tsx
+++ b/client/src/features/SignUp/components/presenter/SignUpModalPresenter.tsx
@@ -27,9 +27,7 @@ import AssignmentIndIcon from '@mui/icons-material/AssignmentInd';
 import CloseIcon from '@mui/icons-material/Close';
 import { type RegistrationFormSchema } from '../schemas/registrationFormSchema';
 
-interface SignUpModalPresenterProps {
-  isOpen: boolean;
-  onClose: () => void;
+interface SignUpFormProps {
   register: UseFormRegister<RegistrationFormSchema>;
   handleSubmit: UseFormHandleSubmit<RegistrationFormSchema>;
   onSubmit: SubmitHandler<RegistrationFormSchema>;
@@ -37,14 +35,16 @@ interface SignUpModalPresenterProps {
   isSubmitting: boolean;
 }
 
+interface SignUpModalPresenterProps {
+  isOpen: boolean;
+  onClose: () => void;
+  form: SignUpFormProps;
+}
+
 const SignUpModalPresenter: FC<SignUpModalPresenterProps> = ({
   isOpen,
   onClose,
-  register,
-  handleSubmit,
-  onSubmit,
-  errors,
-  isSubmitting,
+  form: { register, handleSubmit, onSubmit, errors, isSubmitting },
 }) => {
   return (
     <div>


### PR DESCRIPTION
## 概要

[eslint-plugin-react-max-props](``https://github.com/talasago/eslint-plugin-react-max-props)（開発中の独自ESLintプラグイン）を、既存のプロジェクト設定（ESLint`` 8 / eslintrc）には手を加えず、リポジトリ外の一時検証環境で `client/src` の実コードに対してドッグフーディングした結果を踏まえた修正です。

- プラグイン側を `pnpm build` → `pnpm link --global` でグローバル登録
- 検証専用の最小構成（ESLint 10 + typescript-eslint、`link:` プロトコルでプラグイン参照）を用意し、`client/src` 配下27ファイルに対してmax-propsルール（デフォルト `max: 5`）を実行
- 3件の違反を検出し、いずれもこのPRで解消

## 検出された違反と対処

| コンポーネント | Before | After | 対処内容 |
|---|---|---|---|
| `LoginModalPresenter` | 7 props | 3 props | react-hook-form関連の5個（`register`/`handleSubmit`/`onSubmit`/`errors`/`isSubmitting`）はデータクランプと判断し `form` オブジェクトに集約 |
| `SignUpModalPresenter` | 7 props | 3 props | 同上のパターン |
| `RetrospectiveMethodListPresenter` | 9 props | 3 props | 既に内部で `SearchArea` / `RetrospectiveMethodPaperArea` / `ScrollToTop` の3子コンポーネントに分割済みだったため、Presenterに渡すpropsもその子コンポーネント単位（`searchArea` / `paperArea` / `scrollTop`）でグルーピング |

対応する各Containerの呼び出し側も、上記のprops構造変更に合わせて修正しています。

## 確認したこと

- `npx tsc --noEmit`：型エラーなし
- 既存の `eslint`（プロジェクト本来のESLint 8構成）：エラーなし
- 既存の全Jestテスト（11件）：パス
- ドッグフーディング用の検証環境で再lint：max-props違反 0件

なお、修正対象の3コンポーネントには元々テストが存在しませんでした。

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7dKD7GHWpvtUbL2YmyQLo)_